### PR TITLE
🎮 MC Quiz (3 rounds) + counters added

### DIFF
--- a/routes/quiz.py
+++ b/routes/quiz.py
@@ -65,159 +65,164 @@ def start_quiz():
 def next_questions():
     client = current_app.config['client']
     user_id = get_current_user_id()
+    quiz_round_id = request.args.get('quizroundid')
 
-    # weak word condition: accuracy below 70% or fewer than 3 total answers
-    # limit to 10 vocabs
+    # Get asked this round (optional uniqueness)
+    if quiz_round_id:
+        asked_ids = db.session.query(QuizAnswer.vocab_entry_id).filter(
+            QuizAnswer.quiz_round_id == quiz_round_id
+        ).subquery()
 
+    # Single weak vocab (randomized, exclude asked)
     weak = VocabEntry.query.filter(
         VocabEntry.user_id == user_id,
         (VocabEntry.accuracy_percent < 95) | (VocabEntry.total_answers < 100)
-    ).limit(10).all()
+    )
+    if quiz_round_id:
+        weak = weak.filter(~VocabEntry.id.in_(asked_ids))
+    entry = weak.order_by(func.random()).first()
 
-    print(weak)
+    if not entry:
+        return jsonify({"error": "No weak vocabs available"}), 404
 
-    questions = []
-    for e in weak:
-        latin_word = e.latin_word
-        correct = e.german_translation
+    # Generate distractors for THIS vocab only (1x Gemini ~2s)
+    latin_word = entry.latin_word
+    correct = entry.german_translation
 
-        # Build full set of true meanings (DB + FragCaesar)
-        true_meanings_set = build_true_meanings_set_from_frag_caesar_and_db(
-            correct=correct,
-            latin_word=latin_word,
-        )
+    # Build full set of true meanings (DB + FragCaesar)
+    true_meanings_set = build_true_meanings_set_from_frag_caesar_and_db(
+        correct=correct,
+        latin_word=latin_word,
+    )
 
-        # ---- OpenAI call with fallback + short chat history ----
+    # ---- OpenAI/Gemini call with fallback + short chat history ----
+    system_msg = {
+        "role": "system",
+        "content": (
+            "You are a helpful assistant for Latin–German vocabulary training. "
+            "Always answer ONLY with a JSON array of strings, e.g. "
+            "[\"Wort1\",\"Wort2\",\"Wort3\"]. No explanations."
+        ),
+    }
 
-        system_msg = {
-            "role": "system",
-            "content": (
-                "You are a helpful assistant for Latin–German vocabulary training. "
-                "Always answer ONLY with a JSON array of strings, e.g. "
-                "[\"Wort1\",\"Wort2\",\"Wort3\"]. No explanations."
-            ),
-        }
+    base_user_prompt = (
+        "You get a Latin–German vocabulary pair.\n"
+        "Return EXACTLY three unique, wrong but plausible German translations for the Latin word.\n"
+        "Important:\n"
+        "- Do NOT repeat any of the other given true German meanings.\n"
+        "- Answer ONLY with a JSON array of strings, no extra text.\n\n"
+        f"Latin: {latin_word}\n"
+        f"True German translation: {correct}\n"
+        f"Other true German meanings: {sorted(true_meanings_set)}"
+    )
 
-        base_user_prompt = (
-            "You get a Latin–German vocabulary pair.\n"
-            "Return EXACTLY three unique, wrong but plausible German translations for the Latin word.\n"
-            "Important:\n"
-            "- Do NOT repeat any of the other given true German meanings.\n"
-            "- Answer ONLY with a JSON array of strings, no extra text.\n\n"
-            f"Latin: {latin_word}\n"
-            f"True German translation: {correct}\n"
-            f"Other true German meanings: {sorted(true_meanings_set)}"
-        )
+    messages = [system_msg, {"role": "user", "content": base_user_prompt}]
 
-        messages = [system_msg, {"role": "user", "content": base_user_prompt}]
+    wrong_options_raw: list[str] = []
+    max_wrong_responses = 3  # allow 3 "bad" attempts
+    attempts = 0
 
-        wrong_options_raw: list[str] = []
-        max_wrong_responses = 3  # allow 3 “bad” attempts
-        attempts = 0
+    while attempts < max_wrong_responses:
+        attempts += 1
+        try:
+            resp = client.chat.completions.create(
+                model=OPENAI_MODEL,
+                # model=GEMINI_MODEL,
+                messages=messages,
+                max_tokens=120,
+            )
+            content = resp.choices[0].message.content.strip()
+            current_app.logger.info("AI content for %s (attempt %d): %s", latin_word, attempts, content)
+            wrong_options_raw = json.loads(content)
+            if not isinstance(wrong_options_raw, list):
+                raise ValueError("AI response is not a JSON list")
 
-        while attempts < max_wrong_responses:
-            attempts += 1
-            try:
-
-                resp = client.chat.completions.create(
-                    model=OPENAI_MODEL,
-                    #model=GEMINI_MODEL,
-                    messages=messages,
-                    max_tokens=120,
-                )
-                content = resp.choices[0].message.content.strip()
-                current_app.logger.info("AI content for %s (attempt %d): %s", latin_word, attempts, content)
-                wrong_options_raw = json.loads(content)
-                if not isinstance(wrong_options_raw, list):
-                    raise ValueError("AI response is not a JSON list")
-
-            except Exception as ex:
-                current_app.logger.error("OpenAI error for %s (attempt %d): %s",
-                                         latin_word, attempts, ex)
-                wrong_options_raw = [
-                    "Falsche Übersetzung 1",
-                    "Falsche Übersetzung 2",
-                    "Falsche Übersetzung 3",
-                ]
-                break  # fall through to filtering once, no further retries
-
-
-            # Filter out any distractor that matches a real meaning
-            filtered = []
-            violating = []  # those that matched a true meaning
-
-            for w in wrong_options_raw:
-                if not isinstance(w, str):
-                    continue
-                norm = normalize_german_strict(w)
-                if not norm:
-                    continue
-                if norm in true_meanings_set:
-                    violating.append(w)
-                    continue
-                filtered.append(w.strip())
-
-            # If none of the options violated the true meanings, we accept this response
-            if not violating:
-                wrong_options_raw = filtered
-                break
-
-            # Otherwise, add a brief assistant + user message to the chat history and retry
-            violation_text = ", ".join(f"\"{v}\"" for v in violating)
-            messages.append({
-                "role": "assistant",
-                "content": json.dumps(wrong_options_raw, ensure_ascii=False),
-            })
-            messages.append({
-                "role": "user",
-                "content": (
-                    "Some of your previous suggestions were invalid because they match true German meanings "
-                    f"for this Latin word: {violation_text}.\n"
-                    "Please try again and return three different WRONG translations that do not match any true meaning."
-                ),
-            })
-
-            # If filtered already has 3 or more safe distractors after removing violating ones, we can stop
-            if len(filtered) >= 3:
-                wrong_options_raw = filtered
-                break
-
-            # Otherwise, loop again, letting the new user message guide the model
-
-        # After loop, ensure we have a list of strings in wrong_options_raw (possibly filtered)
-        if not wrong_options_raw:
+        except Exception as ex:
+            current_app.logger.error("OpenAI error for %s (attempt %d): %s",
+                                     latin_word, attempts, ex)
             wrong_options_raw = [
                 "Falsche Übersetzung 1",
                 "Falsche Übersetzung 2",
                 "Falsche Übersetzung 3",
             ]
+            break  # fall through to filtering once, no further retries
 
-        # Final filtering & padding to exactly 3
-        final_filtered = []
+        # Filter out any distractor that matches a real meaning
+        filtered = []
+        violating = []  # those that matched a true meaning
+
         for w in wrong_options_raw:
             if not isinstance(w, str):
                 continue
             norm = normalize_german_strict(w)
-            if not norm or norm in true_meanings_set:
+            if not norm:
                 continue
-            final_filtered.append(w.strip())
+            if norm in true_meanings_set:
+                violating.append(w)
+                continue
+            filtered.append(w.strip())
 
-        wrong_options = final_filtered[:3]
-        while len(wrong_options) < 3:
-            wrong_options.append(f"Other wrong translation {len(wrong_options) + 1}")
+        # If none of the options violated the true meanings, we accept this response
+        if not violating:
+            wrong_options_raw = filtered
+            break
 
-        options = wrong_options + [correct]
-        random.shuffle(options)
-        correct_index = options.index(correct)
-
-        questions.append({
-            "id": e.id,
-            "latin_word": latin_word,
-            "options": options,
-            "correct_index": correct_index,
+        # Otherwise, add a brief assistant + user message to the chat history and retry
+        violation_text = ", ".join(f'"{v}"' for v in violating)
+        messages.append({
+            "role": "assistant",
+            "content": json.dumps(wrong_options_raw, ensure_ascii=False),
+        })
+        messages.append({
+            "role": "user",
+            "content": (
+                "Some of your previous suggestions were invalid because they match true German meanings "
+                f"for this Latin word: {violation_text}.\n"
+                "Please try again and return three different WRONG translations that do not match any true meaning."
+            ),
         })
 
-    return jsonify(questions)
+        # If filtered already has 3 or more safe distractors after removing violating ones, we can stop
+        if len(filtered) >= 3:
+            wrong_options_raw = filtered
+            break
+
+    # After loop, ensure we have a list of strings in wrong_options_raw (possibly filtered)
+    if not wrong_options_raw:
+        wrong_options_raw = [
+            "Falsche Übersetzung 1",
+            "Falsche Übersetzung 2",
+            "Falsche Übersetzung 3",
+        ]
+
+    # Final filtering & padding to exactly 3
+    final_filtered = []
+    for w in wrong_options_raw:
+        if not isinstance(w, str):
+            continue
+        norm = normalize_german_strict(w)
+        if not norm or norm in true_meanings_set:
+            continue
+        final_filtered.append(w.strip())
+
+    wrong_options = final_filtered[:3]
+    while len(wrong_options) < 3:
+        wrong_options.append(f"Other wrong translation {len(wrong_options) + 1}")
+
+    options = wrong_options + [correct]
+    random.shuffle(options)
+    correct_index = options.index(correct)
+
+    question = [{
+        "id": entry.id,
+        "latin_word": latin_word,
+        "options": options,
+        "correct_index": correct_index
+    }]
+
+    current_app.logger.info(f"Single MC question: {latin_word}")
+    return jsonify(question)
+
 
 
 @quiz_bp.route('/verbs/next')
@@ -264,6 +269,8 @@ def answer_question():
     data = request.get_json()
 
     quiz_round_id = data.get("quiz_round_id")
+    if not quiz_round_id:
+        return jsonify({"error": "Missing quiz_round_id"}), 400
     vocab_entry_id = data.get("vocab_entry_id")
     selected_option = (data.get("selected_option") or "").strip().lower()
 

--- a/static/index.html
+++ b/static/index.html
@@ -36,7 +36,7 @@
   </section>
 
 <section id="quizSection" class="panel">
-  <h2>Vocab Multiple Choice Quiz</h2>
+  <h2>Vocab Multiple Choice Quiz <span id="mcCounter" style="color: violet; font-weight: bold;">–</span></h2>
   <div id="quizWord" class="quiz-latin"></div></div>
   <div id="quizOptions"></div>
   <div id="quizFeedback"></div>
@@ -44,7 +44,7 @@
 </section>
 
 <section id="sortingSection" style="display:none;" class="panel">
-  <h2>Verb Sorting Quiz</h2>
+  <h2>Verb Sorting Quiz <span id="sortingCounter" style="color: violet; font-weight: bold;">–</span></h2>
   <div id="sortingQuizArea" class="sorting-area">
     <!-- Draggable Verb Card -->
     <div id="verbCard" class="verb-card" draggable="true">

--- a/static/script.js
+++ b/static/script.js
@@ -3,8 +3,8 @@ console.log("script.js loaded");
 const API_BASE = "http://localhost:5000/api";
 
 let quizRoundId = null;
-let quizQuestions = [];
-let currentIndex = 0;
+let mcVerbCount = 0;
+let sortingVerbCount = 0;
 
 /*
 Vocab section calls /api/vocab/ to list and create VocabEntry rows
@@ -152,37 +152,21 @@ async function startQuizFlow() {
   const startRes = await fetch(`${API_BASE}/quiz/start`, { method: "POST" });
   const startData = await startRes.json();
   quizRoundId = startData.quiz_round_id;
-
-  const qRes = await fetch(`${API_BASE}/quiz/next`);
-  quizQuestions = await qRes.json();
-  console.log("quizQuestions:", quizQuestions);
-
-  currentIndex = 0;
-
-  if (!quizQuestions || quizQuestions.length === 0) {
-    alert("No quiz questions available. Add vocab and/or lower accuracy first.");
-    return;
-  }
-
+  mcVerbCount = 0;
+  document.getElementById('mcCounter').textContent = '';  // Clear
   showSection("quiz");
-  showCurrentQuestion();
+  await loadNextMCQuestion();  // Loads 1st, sets "1/3"
 }
 
 // Render one quiz question (Horizontal buttons like sorting)
-function showCurrentQuestion() {
-  console.log("showCurrentQuestion", currentIndex, quizQuestions[currentIndex]);
-  const q = quizQuestions[currentIndex];
-
+function showCurrentQuestionStandalone(q) {
+  console.log("showCurrentQuestionStandalone", q);
   const wordDiv = document.getElementById("quizWord");
   const optionsDiv = document.getElementById("quizOptions");
   const feedbackDiv = document.getElementById("quizFeedback");
-  const nextBtn = document.getElementById("btnNextQuestion");
-
-  console.log("DOM quiz elements:", wordDiv, optionsDiv, feedbackDiv, nextBtn);
 
   wordDiv.textContent = q.latin_word;
   feedbackDiv.textContent = "";
-  nextBtn.style.display = "none";
 
   // FORCE Horizontal Layout (matches .categories-container exactly)
   optionsDiv.style.cssText = `
@@ -206,6 +190,38 @@ function showCurrentQuestion() {
     btn.style.flex = "0 0 auto";        // Fixed size like .category-box
     optionsDiv.appendChild(btn);
   });
+}
+
+async function loadNextMCQuestion() {
+  if (mcVerbCount >= 3) {
+    // EXACT sorting match
+    document.getElementById('quizFeedback').textContent = 'Multiple choice quiz complete! (3 words)';
+    alert('Multiple choice quiz complete!');
+    await fetch(`${API_BASE}/quiz/finish`, {  // Close round
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ quiz_round_id: quizRoundId })
+    });
+    loadVocab();
+    showSection('vocab');
+    return;
+  }
+
+  const qRes = await fetch(`${API_BASE}/quiz/next?quizroundid=${quizRoundId}`);
+  const newQuestions = await qRes.json();
+  if (!newQuestions || newQuestions.length === 0) {
+    document.getElementById('quizFeedback').textContent = 'No more questions.';
+    return;
+  }
+
+  // Use first question (backend sends array, take [0])
+  const q = newQuestions[0];
+  showCurrentQuestionStandalone(q);  // New func below
+  document.getElementById('quizFeedback').textContent = `Choose the right answer! (${mcVerbCount + 1}/3 words)`;  // Initial instruction
+  mcVerbCount++;
+  document.getElementById('mcCounter').textContent = `${mcVerbCount}/3`;
+
+  document.getElementById('btnNextQuestion').style.display = 'none';
 }
 
 
@@ -242,21 +258,8 @@ async function submitChoice(selectedOption, q) {
 
 // Next question button
 document.getElementById("btnNextQuestion").onclick = async () => {
-  // Hide immediately on click
   document.getElementById("btnNextQuestion").style.display = 'none';
-  currentIndex++;
-  if (currentIndex >= quizQuestions.length) {
-    await fetch(`${API_BASE}/quiz/finish`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ quiz_round_id: quizRoundId })
-    });
-    alert("Quiz finished!");
-    loadVocab();
-    showSection("vocab");
-  } else {
-    showCurrentQuestion();
-  }
+  await loadNextMCQuestion();  // Sequential next (no currentIndex)
 };
 
 // Load cards
@@ -285,10 +288,22 @@ let sortingRoundId = null;
 async function startSortingQuiz() {
   const res = await fetch(`${API_BASE}/quiz/verbs/start`, { method: 'POST' });
   sortingRoundId = (await res.json()).quizroundid;
+  sortingVerbCount = 0;  // Reset
+  document.getElementById('sortingCounter').textContent = '';  // Clear
   await loadNextSortingVerb();
 }
 
 async function loadNextSortingVerb() {
+    // Stop after 3 verbs
+  if (sortingVerbCount >= 3) {
+    document.getElementById('sortingFeedback').textContent = 'Sorting quiz complete! (3 verbs)';
+    document.getElementById('sortingCounter').textContent = '';
+    alert('Sorting quiz complete!');
+    loadVocab();
+    showSection('vocab');
+    return;
+  }
+
   const res = await fetch(`${API_BASE}/quiz/verbs/next?quizroundid=${sortingRoundId}`);
   const data = await res.json();
   if (data.error) {
@@ -298,9 +313,11 @@ async function loadNextSortingVerb() {
     showSection('vocab');
     return;
   }
+  sortingVerbCount++;
   currentVerbData = data;
   document.getElementById('verbCard').textContent = data.verb;
-  document.getElementById('sortingFeedback').textContent = 'Drag to category!';
+  document.getElementById('sortingCounter').textContent = `${sortingVerbCount}/3`;  // Header counter
+  document.getElementById('sortingFeedback').textContent = `Drag to category! (${sortingVerbCount}/3 verbs)`;
   resetCategories();
   // Re-attach drop listeners if needed
 }


### PR DESCRIPTION
**MC Quiz (3 rounds)** Sequential `/next` → 1 vocab/call (~2s vs 15s)
**Counters** Both headers: "1/3" violet + instruction feedback  
**Identical UX** Alert → vocab on complete
**Single-question backend** 1x request  per round, no repeats